### PR TITLE
Fix make protoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,4 @@ import-spec:
 	@mkdir -p spec/github.com/iov-one/weave
 	@cp -r ${WEAVEDIR}/spec/gogo/* spec/github.com/iov-one/weave
 	@chmod -R +w spec
+	@echo '\noption go_package = "github.com/iov-one/weave";' >> spec/github.com/iov-one/weave/codec.proto

--- a/spec/github.com/iov-one/weave/codec.proto
+++ b/spec/github.com/iov-one/weave/codec.proto
@@ -29,3 +29,5 @@ message PubKey {
   string type = 1;
   bytes data = 2;
 }
+
+option go_package = "github.com/iov-one/weave";


### PR DESCRIPTION
I fixed the [bug](https://github.com/iov-one/weave-starter-kit/pull/23#pullrequestreview-273694989) that blocked https://github.com/iov-one/weave-starter-kit/pull/23. 
In https://github.com/gogo/protobuf/issues/601, @apelisse pointed me to the problems cause. It was `spec/github.com/iov-one/weave/codec.proto`.
Reason:
- `includes` field contains which import paths will be used when running protoc.
  - `.` means that `import "x/custom/codec.go"` will work inside this app (recommended to avoid GOPATH issues)
  - `spec` means that we can `import "github.com/iov-one/weave/coins/codec.proto"` and it will use the protobuf file from our spec directory (which must be kept up to date with the weave repo).
  - `spec/github.com/iov-one/weave` is needed as if we import eg. `github.com/iov-one/weave/x/cash/codec.proto`, it imports `coins/codec.proto` using relative imports to it's project. When we then import this via spec, the relative import doesn't work without this second line.

Everything seems okay until running `make protoc`. `spec` folder and `spec/github.com/iov-one/weave` folder includes `weave` package so the protoc generates these imports in `x/custom/codec.pb.go`:
```go
import (
  github_com_iov_one_weave "github.com/iov-one/weave"
  weave "github.com/iov-one/weave"
)
``` 

The duality of `github.com/iov-one/weave` does not effect applications runtime but proto compiler gets confused. Solution is to add 
```go
option go_package = "github.com/iov-one/weave";
```
to `spec/github.com/iov-one/weave/codec.proto`. Now everything returned back to normal in `protoc`'s aspect. **Note**: if you want to read more about `option go_package` here is an [article](https://jbrandhorst.com/post/go-protobuf-tips/). 

If you have a better solution than `Makefile`, please let me know :)
Also thank you @apelisse :)

Resolves https://github.com/gogo/protobuf/issues/601